### PR TITLE
Add type: module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   ],
   "scripts": {
     "test": "echo \"No test specified\""
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
This fixes importing it because Node can recognize that this is an ESM package.