### PR TITLE
Move replace out of scrollIntoView conditional

### DIFF
--- a/buildPage.js
+++ b/buildPage.js
@@ -10,11 +10,11 @@ export default function (
   return `${
     containerSelector
       ? `const newContent = doc.querySelector("${containerSelector}");
+        const container = document.querySelector("${containerSelector}");
+        container.replaceWith(newContent);
         ${
           scrollIntoView
-            ? `const container = document.querySelector("${containerSelector}");
-        container.replaceWith(newContent);
-        newContent.scrollIntoView(${JSON.stringify(scrollIntoViewOptions)});`
+            ? `newContent.scrollIntoView(${JSON.stringify(scrollIntoViewOptions)});`
             : ""
         }
         document.head.replaceWith(doc.head);


### PR DESCRIPTION
This PR resolves and issue where content would not be replaced when `scrollintoView` is disabled and `containerSelector` is also used