### PR TITLE
Enable Non-Node JS Environments (Cloudflare, Deno, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Default: `false`
 
 Whether the code should be included in an external JavaScript file or be inlined. If enabled, the hash of the code will be appended to the filename.
 
+> **Note:** To create an external script the Node Api is used. In Deno/Cloudflare/etc. Environments this will always be `false` and can not be changed
+
 ### forceRequestIdleCallback
 
 Type: `boolean`

--- a/Spa.astro
+++ b/Spa.astro
@@ -1,8 +1,6 @@
 ---
-import fs from "node:fs";
-import crypto from "node:crypto";
-import { minify } from "./terser.js";
 import buildScript from "./script.js";
+import { minify } from "./terser.js";
 
 export interface scrollIntoViewOptions {
   behavior?: "smooth" | "auto";
@@ -108,17 +106,35 @@ const scriptContent = buildScript(
 
 const { code } = await minify(scriptContent);
 
-fs.existsSync("public") || fs.mkdirSync("public");
-
-const path = `public/astro-spa-${crypto
-  .createHash("sha256")
-  .update(code)
-  .digest("hex")
-  .slice(0, 8)}.js`;
+//path will not be used unless external is true
+let path = "";
 
 if (external) {
-  (fs.existsSync(path) && fs.readFileSync(path, "utf8") === code) ||
-    fs.writeFileSync(path, code);
+  import("node:crypto")
+    .then((crypto) => {
+      path = `public/astro-spa-${crypto
+        .createHash("sha256")
+        .update(code)
+        .digest("hex")
+        .slice(0, 8)}.js`;
+    })
+    .catch((err) => {
+      console.error(
+        "Node API Crypto is not available. The script will now inline. This is equal to the option 'external: false'."
+      );
+    });
+
+  import("node:fs")
+    .then((fs) => {
+      fs.existsSync("public") || fs.mkdirSync("public");
+      (fs.existsSync(path) && fs.readFileSync(path, "utf8") === code) ||
+        fs.writeFileSync(path, code);
+    })
+    .catch((err) => {
+      console.error(
+        "Node API fs is not available. The script will now inline. This is equal to the option 'external: false'."
+      );
+    });
 }
 
 const Tag = "script";


### PR DESCRIPTION
Node APIs are only used to externalizing the generated script.  

In Non-Node Environments this used to throw an error.

Now the Node APIs are imported dynamically and the errors in non-Node-Envs are being catched and a message is logged. 